### PR TITLE
Add empty link

### DIFF
--- a/blog/content/2016-07-08-introducing-cesium.md
+++ b/blog/content/2016-07-08-introducing-cesium.md
@@ -2,6 +2,7 @@ Title: Introducing cesium
 Category: cesium
 Status: published
 
+[](https://github.com/cesium-ml)
 From the reading of electroencephalograms (EEGs) to earthquake seismograms to light
 curves of astronomical variable stars, gleaning insight from time series data
 has been central to a broad range of scientific and medical disciplines. When


### PR DESCRIPTION
Fixes the blog post so the entire article is not a link.